### PR TITLE
14 add detector metadata

### DIFF
--- a/mxcubecore/HardwareObjects/ICATLIMS.py
+++ b/mxcubecore/HardwareObjects/ICATLIMS.py
@@ -536,6 +536,26 @@ class ICATLIMS(AbstractLims):
         except Exception as e:
             logging.getLogger("HWR").exception(e)
 
+    def add_beamline_configuration_metadata(self, metadata, beamline_config):
+        """
+        This is the mapping betweeh the beamline_config dict and the ICAt keys
+        in case they exist then they will be added to the metadata of the dataset
+        """
+        if beamline_config is not None:
+            key_mapping = {
+                "detector_px": "InstrumentDetector01_x_pixel_size",
+                "detector_py": "InstrumentDetector01_y_pixel_size",
+                "beam_divergence_vertical": "InstrumentBeam_vertical_incident_beam_divergence",
+                "beam_divergence_horizontal": "InstrumentBeam_horizontal_incident_beam_divergence",
+                "polarisation": "InstrumentBeam_final_polarization",
+                "detector_model": "InstrumentDetector01_model",
+                "detector_manufacturer": "InstrumentDetector01_manufacturer",
+            }
+
+            for config_key, metadata_key in key_mapping.items():
+                if config_key in beamline_config:
+                    metadata[metadata_key] = beamline_config[config_key]
+
     def add_sample_metadata(self, metadata, collection_parameters):
         """
         Adds to the metadata dictionary the metadata concerning sample position, container and tracking
@@ -599,7 +619,8 @@ class ICATLIMS(AbstractLims):
         pass
 
     def store_data_collection(self, mx_collection, bl_config=None):
-        pass
+        # stores the dictionay with the information about the beamline to be sent when a dataset is produced
+        self.beamline_config = bl_config
 
     def update_data_collection(self, mx_collection):
         pass
@@ -684,6 +705,8 @@ class ICATLIMS(AbstractLims):
             }
             # Store metadata on disk
             self.add_sample_metadata(metadata, collection_parameters)
+            self.add_beamline_configuration_metadata(metadata, self.beamline_config)
+
             icat_metadata_path = pathlib.Path(directory) / "metadata.json"
             with open(icat_metadata_path, "w") as f:
                 f.write(json.dumps(metadata, indent=4))


### PR DESCRIPTION
This issue adds some metadata pamateres from the beamline configuration ditc by following the next mapping:
```  "detector_px": "InstrumentDetector01_x_pixel_size",
                "detector_py": "InstrumentDetector01_y_pixel_size",
                "beam_divergence_vertical": "InstrumentBeam_vertical_incident_beam_divergence",
                "beam_divergence_horizontal": "InstrumentBeam_horizontal_incident_beam_divergence",
                "polarisation": "InstrumentBeam_final_polarization",
                "detector_model": "InstrumentDetector01_model",
                "detector_manufacturer": "InstrumentDetector01_manufacturer",