### PR TITLE
19 allow automatic selection when there is a single session available

### DIFF
--- a/mxcubecore/HardwareObjects/ESRFLIMS.py
+++ b/mxcubecore/HardwareObjects/ESRFLIMS.py
@@ -32,14 +32,36 @@ class ESRFLIMS(AbstractLims):
         )
         return self.drac.get_session_id()
 
+    def is_single_session_available(self):
+        """
+        True if there is no active session and there is
+        a single session available
+        """
+        return (
+            self.session_manager.active_session is None
+            and len(self.session_manager.sessions) == 1
+        )
+
     def login(self, user_name, token, is_local_host=False) -> LimsSessionManager:
         self.is_local_host = is_local_host
         session_manager, lims_username, sessions = self.drac.login(
             user_name, token, self.session_manager
         )
         logging.getLogger("HWR").debug(
-            "DRAC sessions=%s" % (len(self.drac.session_manager.sessions),)
+            "%s sessions found. user=%s" % (len(sessions), user_name)
         )
+
+        self.session_manager = self.drac.session_manager
+        self.add_user_and_shared_sessions(lims_username, sessions)
+
+        # In case there is a single available session then it is selected automatically
+        if self.is_single_session_available():
+            single_session = self.session_manager.sessions[0]
+            logging.getLogger("HWR").debug(
+                "Single session available which will be selected automatically. session_id=%s"
+                % (single_session.session_id)
+            )
+            self.set_active_session_by_id(single_session.session_id)
 
         if session_manager.active_session is None:
             logging.getLogger("HWR").debug(
@@ -51,9 +73,6 @@ class ESRFLIMS(AbstractLims):
                 session_manager.active_session.number,
                 self.is_local_host,
             )
-
-        self.session_manager = self.drac.session_manager
-        self.add_user(lims_username, sessions)
         return self.session_manager
 
     def is_user_login_type(self) -> bool:

--- a/mxcubecore/HardwareObjects/abstract/AbstractLims.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractLims.py
@@ -512,7 +512,6 @@ class AbstractLims(HardwareObject, abc.ABC):
         Stores the username and the shared sessions in the session manager object.
         The shared sessions represent the intersection of all sessions
         for each user currently connected.
-
         """
         self.session_manager.users[user_name] = LimsUser(
             user_name=user_name, sessions=sessions

--- a/mxcubecore/HardwareObjects/abstract/AbstractLims.py
+++ b/mxcubecore/HardwareObjects/abstract/AbstractLims.py
@@ -507,12 +507,12 @@ class AbstractLims(HardwareObject, abc.ABC):
             logging.getLogger("HWR").debug("User %s has been removed" % user_name)
             self.__set_sessions(self.get_shared_sessions())
 
-    def add_user(self, user_name: str, sessions: List[Session]):
+    def add_user_and_shared_sessions(self, user_name: str, sessions: List[Session]):
         """
-        Stores the user name and the sessions in the session maanger object
+        Stores the username and the shared sessions in the session manager object.
+        The shared sessions represent the intersection of all sessions
+        for each user currently connected.
 
-        Args:
-            session_id: session id
         """
         self.session_manager.users[user_name] = LimsUser(
             user_name=user_name, sessions=sessions


### PR DESCRIPTION
This fixes #19 and prevents that when there is no active session and a user is connected with a single session available this dialog appears:
![image](https://github.com/user-attachments/assets/ad26d629-31dd-4d73-8b40-5b8286df4296)
