### PR TITLE
[ESRFSession] convert subdir string to a path

### DIFF
--- a/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
+++ b/mxcubecore/HardwareObjects/ESRF/ESRFSession.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import os
 import time
+from pathlib import Path
 from typing import Tuple
 
 from mxcubecore import HardwareRepository as HWR
@@ -53,7 +54,7 @@ class ESRFSession(Session.Session):
 
         :returns: Tuple with the full path to image and processed data
         """
-        subdir = self._sanitize_subdir(subdir).resolve()
+        subdir = Path(self._sanitize_subdir(subdir)).resolve()
 
         if not subdir.is_relative_to(self.get_base_image_directory()):
             error_message = "Invalid subdirectory"


### PR DESCRIPTION
This PR fixes an issue, where the full_path could not be retrieved, since the subdir sanitization function returns a `string` instead of a `Path`